### PR TITLE
redis 적용하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	annotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/hyunbenny/snsApplication/configuration/AuthenticationConfig.java
+++ b/src/main/java/com/hyunbenny/snsApplication/configuration/AuthenticationConfig.java
@@ -25,14 +25,15 @@ public class AuthenticationConfig extends WebSecurityConfigurerAdapter {
     @Override
     public void configure(WebSecurity web) throws Exception {
         // /api/ 로 시작하는 요청들만 통과를 시키고 아닌 경우는 무시한다.
-        web.ignoring().regexMatchers("^(?!/api/).*");
+        web.ignoring().regexMatchers("^(?!/api/).*")
+                .antMatchers("/api/*/users/join", "/api/*/users/login"); // 토큰 필터 적용을 제외하기 위해서 아래에 있던 걸 여기로 옮김(라인을 지우지 않고 주석처리 함)
     }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.csrf().disable()
                 .authorizeHttpRequests()
-                .antMatchers("/api/*/users/join", "/api/*/users/login").permitAll()
+//                .antMatchers("/api/*/users/join", "/api/*/users/login").permitAll()
                 .antMatchers("/api/**").authenticated()
                 .anyRequest().permitAll()
 

--- a/src/main/java/com/hyunbenny/snsApplication/configuration/RedisConfiguration.java
+++ b/src/main/java/com/hyunbenny/snsApplication/configuration/RedisConfiguration.java
@@ -1,0 +1,45 @@
+package com.hyunbenny.snsApplication.configuration;
+
+import com.hyunbenny.snsApplication.model.User;
+import io.lettuce.core.RedisURI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+@RequiredArgsConstructor
+public class RedisConfiguration {
+
+    /**
+     * 캐싱할 때, 데이터의 변경이 너무 잦은 데이터는 캐싱의 의미가 없다.
+     * 따라서 변경이 많지 않고, 접근을 자주 하는(자주 사용하는) 데이터를 캐싱하는 것이 좋다.
+     */
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisURI redisURI = RedisURI.create(redisProperties.getUrl());
+        org.springframework.data.redis.connection.RedisConfiguration configuration = LettuceConnectionFactory.createRedisConfiguration(redisURI);
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(configuration);
+        factory.afterPropertiesSet();
+        return factory;
+    }
+    @Bean
+    public RedisTemplate<String, User> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate redisTemplate = new RedisTemplate();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<User>(User.class));
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/hyunbenny/snsApplication/model/User.java
+++ b/src/main/java/com/hyunbenny/snsApplication/model/User.java
@@ -1,8 +1,11 @@
 package com.hyunbenny.snsApplication.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.hyunbenny.snsApplication.model.entity.UserEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -12,12 +15,16 @@ import java.util.Collection;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class User implements UserDetails {
 
     private Long id;
 
     private String username;
+
+    private String password;
 
     private Roles role;
 
@@ -31,6 +38,7 @@ public class User implements UserDetails {
         return new User(
                 entity.getId(),
                 entity.getUsername(),
+                entity.getPassword(),
                 entity.getRole(),
                 entity.getCreatedAt(),
                 entity.getUpdatedAt(),
@@ -39,32 +47,46 @@ public class User implements UserDetails {
     }
 
     @Override
+    @JsonIgnore
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority(this.getRole().toString()));
     }
 
     @Override
-    public String getPassword() {
-        return this.username;
-    }
-
-    @Override
+    @JsonIgnore
     public boolean isAccountNonExpired() {
         return this.deletedAt == null;
     }
 
     @Override
+    @JsonIgnore
     public boolean isAccountNonLocked() {
         return this.deletedAt == null;
     }
 
     @Override
+    @JsonIgnore
     public boolean isCredentialsNonExpired() {
         return this.deletedAt == null;
     }
 
     @Override
+    @JsonIgnore
     public boolean isEnabled() {
         return this.deletedAt == null;
+    }
+
+    @Override
+    @JsonIgnore
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", username='" + username + '\'' +
+                ", password='" + password + '\'' +
+                ", role=" + role +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", deletedAt=" + deletedAt +
+                '}';
     }
 }

--- a/src/main/java/com/hyunbenny/snsApplication/repository/UserCacheRepository.java
+++ b/src/main/java/com/hyunbenny/snsApplication/repository/UserCacheRepository.java
@@ -1,0 +1,38 @@
+package com.hyunbenny.snsApplication.repository;
+
+import com.hyunbenny.snsApplication.model.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class UserCacheRepository {
+
+    private final RedisTemplate<String, User> userRedisTemplate;
+    private final static Duration USER_CACHE_TTL = Duration.ofDays(3);
+
+    public void setUser(User user) {
+        String key = getKey(user.getUsername());
+        log.info("set User to Redis : {}, {}", key, user);
+        userRedisTemplate.opsForValue().set(key, user, USER_CACHE_TTL);
+    }
+
+    public Optional<User> getUser(String username) {
+        String key = getKey(username);
+        User user = userRedisTemplate.opsForValue().get(key);
+        log.info("get User from Redis : {}, {}", key, user);
+        return Optional.ofNullable(user);
+    }
+
+    private String getKey(String username) {
+        return "USER:" + username;
+    }
+
+
+}

--- a/src/main/java/com/hyunbenny/snsApplication/service/UserService.java
+++ b/src/main/java/com/hyunbenny/snsApplication/service/UserService.java
@@ -7,9 +7,11 @@ import com.hyunbenny.snsApplication.model.User;
 import com.hyunbenny.snsApplication.model.entity.AlarmEntity;
 import com.hyunbenny.snsApplication.model.entity.UserEntity;
 import com.hyunbenny.snsApplication.repository.AlarmEntityRepository;
+import com.hyunbenny.snsApplication.repository.UserCacheRepository;
 import com.hyunbenny.snsApplication.repository.UserEntityRepository;
 import com.hyunbenny.snsApplication.util.JwtTokenUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,12 +21,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserEntityRepository userEntityRepository;
     private final AlarmEntityRepository alarmEntityRepository;
+    private final UserCacheRepository userCacheRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Value("${jwt.token.secretKey}")
@@ -34,10 +38,9 @@ public class UserService {
     private Long expiredMs;
 
     public User loadByUsername(String username) {
-        UserEntity userEntity = userEntityRepository.findByUsername(username).orElseThrow(()
-                -> new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not found", username)));
-
-        return User.fromEntity(userEntity);
+        return userCacheRepository.getUser(username).orElseGet(() ->
+                userEntityRepository.findByUsername(username).map(User::fromEntity).orElseThrow(()
+                -> new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not found", username))));
     }
 
     @Transactional
@@ -55,13 +58,16 @@ public class UserService {
 
     public String login(String username, String password) {
         // 가입한 유저인지 확인
-        UserEntity userEntity = userEntityRepository.findByUsername(username).orElseThrow(()
-                -> new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not found", username)));
+        User user = loadByUsername(username);
+
+        // 유저 레디스 캐시에 세팅
+        userCacheRepository.setUser(user);
 
         // 비밀번호 일치여부 확인
-        if(!bCryptPasswordEncoder.matches(password, userEntity.getPassword()))
+        if(!bCryptPasswordEncoder.matches(password, user.getPassword())) {
             throw new SnsApplicationException(ErrorCode.INVALID_PASSWORD);
-        
+        }
+
         // 토큰 생성
         return JwtTokenUtils.generateToken(username, secretKey, expiredMs);
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,8 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+  redis:
+    url: redis://:pf34f21243ff91a3d4fada03dbaed9e363631e4945e4314bec3b44a35ceea8c23@ec2-54-145-215-74.compute-1.amazonaws.com:24709
 
 jwt:
   token:


### PR DESCRIPTION
- redis 사용을 위해 build.gradle에 의존성 추가
- reids 사용을 위한 redis 설정 정보 추가
- 토큰 정보를 조회할 때 매번 DB에서 유저 정보를 가져오는데 로그인을 할 때 redis에 캐시를 저장해두고 꺼내서 사용할 수 있도록 수정함.
- 로그인과 회원가입 api는 토큰검증 필터에서 제외되도록 수정함.

This closes #19 